### PR TITLE
Support running the autoscaler from within the cluster

### DIFF
--- a/autoscaler/cluster_update.py
+++ b/autoscaler/cluster_update.py
@@ -162,9 +162,12 @@ class gce_cluster_control(abstract_cluster_control):
         managers = self.compute.instanceGroupManagers().list(
             zone=self.zone, project=self.project).execute()['items']
         matches = []
-        for manager in managers:
-            if segment in manager['name']:
-                matches.append(manager)
+        if segment == 'incluster':
+            matches = managers
+        else:
+            for manager in managers:
+                if segment in manager['name']:
+                    matches.append(manager)
         if len(matches) == 0:
             scale_logger.exception(
                 "Could not find context %s in Google Cloud project\n" % segment)

--- a/autoscaler/kubernetes_control.py
+++ b/autoscaler/kubernetes_control.py
@@ -56,6 +56,10 @@ class k8s_control:
     def _configure_new_context(self, new_context):
         """ Loads .kube config to instantiate kubernetes
         with specified context"""
+        if new_context == 'incluster':
+            config.load_incluster_config()
+            return 'incluster'
+
         contexts, _ = config.list_kube_config_contexts()
         try:
             contexts = [c['name'] for c in contexts]

--- a/autoscaler/main.py
+++ b/autoscaler/main.py
@@ -51,7 +51,8 @@ def main():
         "--context",
         required=True,
         help="A unique segment in the context name to specify which to \
-        use to instantiate Kubernetes"
+        use to instantiate Kubernetes, or 'incluster' to denote that the \
+        autoscaler is running within the cluster."
     )
     parser.add_argument(
         "--context-for-cloud",

--- a/autoscaler/main.py
+++ b/autoscaler/main.py
@@ -87,8 +87,7 @@ def main():
                 "Running in test kubernetes mode, no action on node specs")
 
     if args.y:
-        def confirm(x, y=False):
-            return True
+        options.confirm = False
 
     options.context = args.context
     if args.context_for_cloud != "":

--- a/autoscaler/settings.py
+++ b/autoscaler/settings.py
@@ -45,6 +45,7 @@ class settings:
 
         self.context = ""
         self.context_cloud = ""
+        self.confirm = True
 
         self.slack_token = os.environ.get("SLACK_TOKEN", "")
 


### PR DESCRIPTION
This gives the `-c` option a new `incluster` argument to tell it not to look for configuration in `~/.kube`, but to use the cluster that it's running in.

Separately, it fixes the `-y` option in the autoscaling script, so it's suitable to be run from a batch job.

Please look this over carefully -- I'm completely new to kubernetes!